### PR TITLE
Custom domain and TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,13 @@
 
 Brian Zelip's home page.
 
-This iteration follows [my most recent GitHub Pages and jekyll powered home page](https://github.com/brianzelip/brianzelip.github.io). This new version looks the same as the jekyll site, but is written in javascript and [hosted on netlify](https://zelip.netlify.com).
-
-I [tried using Gridsome](https://github.com/brianzelip/zelip.me/tree/1cff5c6bd92147537625aeb78f0ecf3065a386d3), but couldn't get it to work with markdown in the way that I want. I've been happier working with one less abstraction layer.
-
-[mdx](https://mdxjs.com) isn't ready for Vue yet.
-
-The environment of this version is based around Parcel. The stack is:
+Development stack:
 
 - [Parcel](https://parceljs.org), bundler environment
-- [Vue](https://vuejs.org), component-driven development
-- [parcel-plugin-markdown-string](https://github.com/jaywcjlove/parcel-plugin-markdown-string), markdown files to strings
+- [Vue](https://vuejs.org), component-driven javascript development
+- [parcel-plugin-markdown-string](https://github.com/jaywcjlove/parcel-plugin-markdown-string), convert markdown files to strings
 - [markdown-it](https://github.com/markdown-it/markdown-it), render markdown in javascript
 - [parcel-plugin-prerender](https://github.com/ABuffSeagull/parcel-plugin-prerender), prerender the vue app into a static site
 - [parcel-plugin-purgecss](https://github.com/cprecioso/parcel-plugin-purgecss), ship the minimum css
+- [GitHub](), source code repository
+- [Netlify](), continuous deployment from a git repository, HTTPS/TLS certificate via Let's Encrypt

--- a/changelog.md
+++ b/changelog.md
@@ -121,3 +121,12 @@ removeElement.js does the following:
 1. finds file to remove element from based on argument (dist/index.html)
 2. removes element from file
 3. saves file
+
+4. Point custom domain at netlify
+
+- starting point: v0.5.0
+- ending point: v1.0.0
+- starting branch: domain
+- steps:
+  - change pointers in godaddy
+  - deprecate brianzelip.github.io

--- a/changelog.md
+++ b/changelog.md
@@ -122,6 +122,8 @@ removeElement.js does the following:
 2. removes element from file
 3. saves file
 
+---
+
 4. Point custom domain at netlify
 
 - starting point: v0.5.0
@@ -130,3 +132,21 @@ removeElement.js does the following:
 - steps:
   - change pointers in godaddy
   - deprecate brianzelip.github.io
+
+Netlify custom domain set up resources:
+
+1. [Custom Domains](https://www.netlify.com/docs/custom-domains/)
+2. [To WWW or not WWW](https://www.netlify.com/blog/2017/02/28/to-www-or-not-www/)
+3. [Manual DNS Configuration for Root and WWW Custom Domains](https://www.netlify.com/docs/custom-domains/#manual)
+
+- This screenshot was particulary useful for configuring Godaddy DNS:
+
+![Godaddy DNS records panel](https://cdn.netlify.com/ea7e82783411b2f0cdf69136d492cb69215470c0/a1706/img/blog/godaddy-dns-records.png)
+
+Here is the documentation for the records that I added to my Goadaddy DNS config for this branch work:
+
+```tsv
+CNAME	www	zelip.netlify.com	1 Hour
+
+A	@	104.198.14.52	1 Hour
+```

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <link rel="stylesheet" href="./src/css/main.css" />
     <title>Brian Zelip</title>
+    <meta name="description" content="Brian Zelip's personal home page." />
+    <meta name="author" content="Brian Zelip" />
   </head>
   <body class="bg-dusty-blue px3">
     <div id="app"></div>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <link rel="stylesheet" href="./src/css/main.css" />
     <title>Brian Zelip</title>
-    <meta name="description" content="Brian Zelip's personal home page." />
+    <meta name="description" content="Brian Zelip's home page." />
     <meta name="author" content="Brian Zelip" />
   </head>
   <body class="bg-dusty-blue px3">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zelip.me",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zelip.me",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "description": "Brian Zelip's home page.",
   "author": {
     "name": "Brian Zelip",


### PR DESCRIPTION
This PR adds:

- https://www.zelip.me
- https://zelip.me
- custom domain management via Netlify
- TLS Let's Encrypt cert
- automatic redirection from the root domain to the www subdomain

This PR deprecates [brianzelip.github.io](https://github.com/brianzelip/brianzelip.github.io).