### PR TITLE
Slim css

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -303,3 +303,14 @@ steps:
 1. delete src/css/basscss
 2. install basscss@7.1.1
 3. update main.css
+
+## 9. Slim down local (non-dependency) css files
+
+- starting point: v1.2.0
+- ending point: v1.2.1
+- branch: slim-css
+
+steps:
+
+- remove some of the unused css classes from design explorations
+- remove some long meta comments in meta.css

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zelip.me",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zelip.me",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Brian Zelip's home page.",
   "author": {
     "name": "Brian Zelip",

--- a/src/css/meta.css
+++ b/src/css/meta.css
@@ -1,9 +1,4 @@
 @charset "UTF-8";
-/* this file is a hack around the way parcel builds
-   asset trees and uses cssnano, ie: when this data 
-   is included at the top of ./main.css, the parcel
-   output starts with all the includes first, then 
-   includes this data, see https://parceljs.org/transforms.html#set-cssnano-minify-config */
 /*!
   *******************************************
   * zelip.me.css                            *

--- a/src/css/zelip.me.css
+++ b/src/css/zelip.me.css
@@ -179,30 +179,3 @@ a {
 .fw-200 {
   font-weight: 200;
 }
-.hello {
-  color: red;
-}
-.goodbye {
-  color: white;
-}
-.fuck {
-  padding: 2rem;
-}
-.double-fuck {
-  padding: 4rem;
-}
-.triple-fuck {
-  padding: 6rem;
-}
-.wtf {
-  color: black;
-}
-.fuckfuck {
-  color: purple;
-}
-.shit {
-  color: brown;
-}
-.real_shit {
-  color: yellow;
-}


### PR DESCRIPTION
This PR slims down the explicit project css files by:

- removing the origin statement comment in meta.css
- removes some now unused color iterations from previous design explorations in zelip.me.css

Closes #17 